### PR TITLE
feat(ui): add reusable ui components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import LoginPage from './features/auth/pages/LoginPage';
 import RegisterPage from './features/auth/pages/RegisterPage';
 import MoviesPage from './features/movies/pages/MoviesPage';
 import MovieDetailPage from './features/movies/pages/MovieDetailPage';
+import UiComponentsTestPage from './pages/UiComponentsTestPage';
 // import BookingPage from './features/booking/pages/BookingPage';
 
 function App() {
@@ -19,6 +20,7 @@ function App() {
         <Route path="/offers" element={<div>Offers Page</div>} />
         <Route path="/news" element={<div>News Page</div>} />
         <Route path="/member" element={<div>Member Page</div>} />
+        <Route path="/ui-components-test" element={<UiComponentsTestPage />} />
       </Route>
 
       {/* Auth Routes (without AppLayout) */}

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -7,3 +7,24 @@
  *
  * Dev phụ A (Tín) phụ trách
  */
+
+import { Button as MantineButton, type ButtonProps as MantineButtonProps } from '@mantine/core';
+import type React from 'react';
+
+export interface ButtonProps
+  extends MantineButtonProps {
+	className?: string;
+	children?: React.ReactNode;
+	onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+export const Button: React.FC<ButtonProps> = ({ className, children, ...props }) => {
+	const baseClassName =
+		'rounded-xl font-semibold transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60';
+
+	return (
+		<MantineButton className={[baseClassName, className].filter(Boolean).join(' ')} {...props}>
+			{children}
+		</MantineButton>
+	);
+};

--- a/client/src/components/ui/ConfirmDialog.tsx
+++ b/client/src/components/ui/ConfirmDialog.tsx
@@ -1,9 +1,63 @@
-/**
- * ConfirmDialog — Reusable UI Component
- *
- * Dùng: Mantine component + Tailwind CSS
- * Props: định nghĩa interface ConfirmDialogProps với TypeScript
- * Export: React.FC<ConfirmDialogProps>
- *
- * Dev phụ A (Tín) phụ trách
- */
+import { Modal, Text, Group, type ModalProps } from '@mantine/core';
+import type React from 'react';
+import { Button } from './Button';
+
+export interface ConfirmDialogProps
+	extends Omit<ModalProps, 'opened' | 'onClose' | 'title' | 'children'> {
+	opened: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	title?: React.ReactNode;
+	message?: React.ReactNode;
+	confirmText?: string;
+	cancelText?: string;
+	loading?: boolean;
+	danger?: boolean;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+	opened,
+	onClose,
+	onConfirm,
+	title = 'Xác nhận thao tác',
+	message = 'Bạn có chắc chắn muốn tiếp tục?',
+	confirmText = 'Xác nhận',
+	cancelText = 'Hủy',
+	loading = false,
+	danger = false,
+	...modalProps
+}) => {
+	return (
+		<Modal
+			opened={opened}
+			onClose={onClose}
+			title={title}
+			centered
+			radius="lg"
+			classNames={{
+				title: 'font-semibold',
+				body: 'pt-2',
+			}}
+			{...modalProps}
+		>
+			<div className="space-y-5">
+				<Text size="sm" c="dimmed" className="leading-relaxed">
+					{message}
+				</Text>
+
+				<Group justify="flex-end" gap="sm">
+					<Button variant="default" onClick={onClose} disabled={loading}>
+						{cancelText}
+					</Button>
+					<Button
+						color={danger ? 'red' : 'blue'}
+						onClick={onConfirm}
+						loading={loading}
+					>
+						{confirmText}
+					</Button>
+				</Group>
+			</div>
+		</Modal>
+	);
+};

--- a/client/src/components/ui/DataTable.tsx
+++ b/client/src/components/ui/DataTable.tsx
@@ -7,3 +7,169 @@
  *
  * Dev phụ A (Tín) phụ trách
  */
+
+import {
+	Box,
+	Center,
+	Loader,
+	Pagination,
+	Paper,
+	ScrollArea,
+	Table,
+	Text,
+} from '@mantine/core';
+import type React from 'react';
+
+type RowData = Record<string, unknown>;
+
+export interface DataTableColumn {
+	key: string;
+	header: React.ReactNode;
+	render?: (row: RowData, rowIndex: number) => React.ReactNode;
+	align?: 'left' | 'center' | 'right';
+	width?: number | string;
+	className?: string;
+	headerClassName?: string;
+}
+
+export interface DataTablePagination {
+	page: number;
+	total: number;
+	onChange: (page: number) => void;
+	siblings?: number;
+	boundaries?: number;
+	withEdges?: boolean;
+}
+
+export interface DataTableProps {
+	columns: DataTableColumn[];
+	data: RowData[];
+	rowKey?: string | ((row: RowData, index: number) => React.Key);
+	loading?: boolean;
+	emptyText?: React.ReactNode;
+	minWidth?: number;
+	className?: string;
+	striped?: boolean;
+	highlightOnHover?: boolean;
+	pagination?: DataTablePagination;
+}
+
+const getCellValue = (value: unknown): React.ReactNode => {
+	if (value === null || value === undefined || value === '') {
+		return '-';
+	}
+
+	if (typeof value === 'boolean') {
+		return value ? 'Có' : 'Không';
+	}
+
+	if (typeof value === 'object') {
+		return JSON.stringify(value);
+	}
+
+	return String(value);
+};
+
+export const DataTable: React.FC<DataTableProps> = ({
+	columns,
+	data,
+	rowKey,
+	loading = false,
+	emptyText = 'Không có dữ liệu',
+	minWidth = 900,
+	className,
+	striped = true,
+	highlightOnHover = true,
+	pagination,
+}) => {
+	return (
+		<Paper withBorder radius="lg" className={className}>
+			<ScrollArea>
+				<Box miw={minWidth}>
+					<Table
+						striped={striped}
+						highlightOnHover={highlightOnHover}
+						verticalSpacing="sm"
+						horizontalSpacing="md"
+						className="text-sm"
+					>
+						<Table.Thead className="bg-slate-50">
+							<Table.Tr>
+								{columns.map((column) => (
+									<Table.Th
+										key={column.key}
+										ta={column.align ?? 'left'}
+										w={column.width}
+										className={column.headerClassName}
+									>
+										{column.header}
+									</Table.Th>
+								))}
+							</Table.Tr>
+						</Table.Thead>
+
+						<Table.Tbody>
+							{loading ? (
+								<Table.Tr>
+									<Table.Td colSpan={Math.max(columns.length, 1)}>
+										<Center py="xl">
+											<Loader size="sm" />
+										</Center>
+									</Table.Td>
+								</Table.Tr>
+							) : data.length === 0 ? (
+								<Table.Tr>
+									<Table.Td colSpan={Math.max(columns.length, 1)}>
+										<Center py="xl">
+											<Text c="dimmed" size="sm">
+												{emptyText}
+											</Text>
+										</Center>
+									</Table.Td>
+								</Table.Tr>
+							) : (
+								data.map((row, rowIndex) => {
+									const key =
+										typeof rowKey === 'function'
+											? rowKey(row, rowIndex)
+											: typeof rowKey === 'string'
+												? (row[rowKey] as React.Key) ?? rowIndex
+												: rowIndex;
+
+									return (
+										<Table.Tr key={key}>
+											{columns.map((column) => (
+												<Table.Td
+													key={`${String(key)}-${column.key}`}
+													ta={column.align ?? 'left'}
+													className={column.className}
+												>
+													{column.render
+														? column.render(row, rowIndex)
+														: getCellValue(row[column.key])}
+												</Table.Td>
+											))}
+										</Table.Tr>
+									);
+								})
+							)}
+						</Table.Tbody>
+					</Table>
+				</Box>
+			</ScrollArea>
+
+			{pagination && pagination.total > 1 && (
+				<div className="flex justify-end px-4 py-3 border-t border-slate-200">
+					<Pagination
+						value={pagination.page}
+						total={pagination.total}
+						onChange={pagination.onChange}
+						siblings={pagination.siblings ?? 1}
+						boundaries={pagination.boundaries ?? 1}
+						withEdges={pagination.withEdges ?? true}
+					/>
+				</div>
+			)}
+		</Paper>
+	);
+};

--- a/client/src/components/ui/EmptyState.tsx
+++ b/client/src/components/ui/EmptyState.tsx
@@ -7,3 +7,79 @@
  *
  * Dev phụ A (Tín) phụ trách
  */
+import { Stack, Text, ThemeIcon, Title } from '@mantine/core';
+import type React from 'react';
+import { Button } from './Button';
+
+export interface EmptyStateProps {
+	title?: React.ReactNode;
+	description?: React.ReactNode;
+	icon?: React.ReactNode;
+	actionLabel?: string;
+	onAction?: () => void;
+	actionLoading?: boolean;
+	className?: string;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+	title = 'Không có dữ liệu',
+	description = 'Hiện chưa có thông tin để hiển thị.',
+	icon,
+	actionLabel,
+	onAction,
+	actionLoading = false,
+	className,
+}) => {
+	const defaultIcon = (
+		<svg
+			className="w-7 h-7"
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+		>
+			<path
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth={1.75}
+				d="M9.172 9a4 4 0 015.656 0M9 15h6m-9 6h12a2 2 0 002-2V7a2 2 0 00-2-2h-2.343a1 1 0 01-.707-.293l-1.414-1.414A1 1 0 0012.828 3h-1.656a1 1 0 00-.707.293L9.05 4.707A1 1 0 018.343 5H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+			/>
+		</svg>
+	);
+
+	return (
+		<div
+			className={[
+				'rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-8 md:p-10',
+				className,
+			]
+				.filter(Boolean)
+				.join(' ')}
+		>
+			<Stack align="center" gap="md">
+				<ThemeIcon
+					size={56}
+					radius="xl"
+					variant="light"
+					color="gray"
+					className="text-slate-600"
+				>
+					{icon ?? defaultIcon}
+				</ThemeIcon>
+
+				<Title order={4} ta="center" className="text-slate-900">
+					{title}
+				</Title>
+
+				<Text size="sm" c="dimmed" ta="center" maw={480} className="leading-relaxed">
+					{description}
+				</Text>
+
+				{actionLabel && onAction && (
+					<Button mt="xs" onClick={onAction} loading={actionLoading}>
+						{actionLabel}
+					</Button>
+				)}
+			</Stack>
+		</div>
+	);
+};

--- a/client/src/components/ui/FormField.tsx
+++ b/client/src/components/ui/FormField.tsx
@@ -7,3 +7,39 @@
  *
  * Dev phụ A (Tín) phụ trách
  */
+import { Input, type InputWrapperProps } from '@mantine/core';
+import type React from 'react';
+
+export interface FormFieldProps
+	extends Omit<InputWrapperProps, 'children' | 'labelElement'> {
+	children: React.ReactNode;
+	className?: string;
+	contentClassName?: string;
+}
+
+export const FormField: React.FC<FormFieldProps> = ({
+	children,
+	className,
+	contentClassName,
+	...wrapperProps
+}) => {
+	return (
+		<Input.Wrapper
+			{...wrapperProps}
+			className={[
+				'space-y-1',
+				className,
+			]
+				.filter(Boolean)
+				.join(' ')}
+			classNames={{
+				label: 'text-sm font-semibold text-slate-700',
+				required: 'text-red-500',
+				description: 'text-xs text-slate-500',
+				error: 'text-xs',
+			}}
+		>
+			<div className={contentClassName}>{children}</div>
+		</Input.Wrapper>
+	);
+};

--- a/client/src/components/ui/LoadingSpinner.tsx
+++ b/client/src/components/ui/LoadingSpinner.tsx
@@ -7,3 +7,48 @@
  *
  * Dev phụ A (Tín) phụ trách
  */
+import { Center, Loader, Text, type LoaderProps } from '@mantine/core';
+import type React from 'react';
+
+export interface LoadingSpinnerProps extends LoaderProps {
+	label?: React.ReactNode;
+	fullScreen?: boolean;
+	overlay?: boolean;
+	minHeight?: number | string;
+	className?: string;
+}
+
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+	label = 'Đang tải dữ liệu...',
+	fullScreen = false,
+	overlay = false,
+	minHeight = 220,
+	className,
+	...loaderProps
+}) => {
+	const wrapperClassName = [
+		'w-full',
+		overlay ? 'absolute inset-0 bg-white/70 backdrop-blur-[1px] z-20' : '',
+		className,
+	]
+		.filter(Boolean)
+		.join(' ');
+
+	return (
+		<Center
+			className={wrapperClassName}
+			style={{
+				minHeight: fullScreen ? '100vh' : minHeight,
+			}}
+		>
+			<div className="flex flex-col items-center gap-3">
+				<Loader size="lg" color="red" {...loaderProps} />
+				{label ? (
+					<Text size="sm" c="dimmed" fw={500} ta="center">
+						{label}
+					</Text>
+				) : null}
+			</div>
+		</Center>
+	);
+};

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,9 +1,71 @@
-/**
- * Modal — Reusable UI Component
- *
- * Dùng: Mantine component + Tailwind CSS
- * Props: định nghĩa interface ModalProps với TypeScript
- * Export: React.FC<ModalProps>
- *
- * Dev phụ A (Tín) phụ trách
- */
+import { Group, Modal as MantineModal, Text, type ModalProps as MantineModalProps } from '@mantine/core';
+import type React from 'react';
+import { Button } from './Button';
+
+export interface ModalProps
+	extends Omit<MantineModalProps, 'children' | 'opened' | 'onClose' | 'title'> {
+	opened: boolean;
+	onClose: () => void;
+	title?: React.ReactNode;
+	children?: React.ReactNode;
+	description?: React.ReactNode;
+	showFooter?: boolean;
+	cancelText?: string;
+	confirmText?: string;
+	onConfirm?: () => void;
+	confirmLoading?: boolean;
+	hideCancelButton?: boolean;
+}
+
+export const Modal: React.FC<ModalProps> = ({
+	opened,
+	onClose,
+	title,
+	children,
+	description,
+	showFooter = false,
+	cancelText = 'Hủy',
+	confirmText = 'Xác nhận',
+	onConfirm,
+	confirmLoading = false,
+	hideCancelButton = false,
+	...modalProps
+}) => {
+	return (
+		<MantineModal
+			opened={opened}
+			onClose={onClose}
+			title={title}
+			centered
+			radius="lg"
+			classNames={{
+				title: 'text-base font-semibold text-slate-900',
+				body: 'pt-1',
+			}}
+			{...modalProps}
+		>
+			<div className="space-y-5">
+				{description ? (
+					<Text size="sm" c="dimmed" className="leading-relaxed">
+						{description}
+					</Text>
+				) : null}
+
+				{children}
+
+				{showFooter && (
+					<Group justify="flex-end" gap="sm" className="pt-2 border-t border-slate-200">
+						{!hideCancelButton && (
+							<Button variant="default" onClick={onClose} disabled={confirmLoading}>
+								{cancelText}
+							</Button>
+						)}
+						<Button onClick={onConfirm} loading={confirmLoading} disabled={!onConfirm}>
+							{confirmText}
+						</Button>
+					</Group>
+				)}
+			</div>
+		</MantineModal>
+	);
+};

--- a/client/src/components/ui/StatusBadge.tsx
+++ b/client/src/components/ui/StatusBadge.tsx
@@ -7,3 +7,95 @@
  *
  * Dev phụ A (Tín) phụ trách
  */
+import { Badge, type BadgeProps } from '@mantine/core';
+import type React from 'react';
+
+type PresetStatus =
+	| 'UPCOMING'
+	| 'RELEASED'
+	| 'ENDED'
+	| 'PENDING'
+	| 'PAID'
+	| 'CANCELLED'
+	| 'COMPLETED'
+	| 'OPEN'
+	| 'FINISHED'
+	| 'BRONZE'
+	| 'SILVER'
+	| 'GOLD'
+	| 'EARN'
+	| 'REDEEM'
+	| 'EXPIRE';
+
+interface StatusMeta {
+	label: string;
+	color: BadgeProps['color'];
+	variant?: BadgeProps['variant'];
+}
+
+const STATUS_META: Record<PresetStatus, StatusMeta> = {
+	UPCOMING: { label: 'Sắp chiếu', color: 'blue', variant: 'light' },
+	RELEASED: { label: 'Đang chiếu', color: 'green', variant: 'light' },
+	ENDED: { label: 'Ngừng chiếu', color: 'gray', variant: 'light' },
+
+	PENDING: { label: 'Chờ thanh toán', color: 'yellow', variant: 'light' },
+	PAID: { label: 'Đã thanh toán', color: 'green', variant: 'light' },
+	CANCELLED: { label: 'Đã hủy', color: 'red', variant: 'light' },
+	COMPLETED: { label: 'Hoàn thành', color: 'teal', variant: 'light' },
+
+	OPEN: { label: 'Đang mở bán', color: 'green', variant: 'light' },
+	FINISHED: { label: 'Đã kết thúc', color: 'gray', variant: 'light' },
+
+	BRONZE: { label: 'Bronze', color: 'orange', variant: 'light' },
+	SILVER: { label: 'Silver', color: 'gray', variant: 'light' },
+	GOLD: { label: 'Gold', color: 'yellow', variant: 'light' },
+
+	EARN: { label: 'Cộng điểm', color: 'green', variant: 'light' },
+	REDEEM: { label: 'Đổi điểm', color: 'blue', variant: 'light' },
+	EXPIRE: { label: 'Hết hạn', color: 'red', variant: 'light' },
+};
+
+export interface StatusBadgeProps
+	extends Omit<BadgeProps, 'children' | 'color' | 'variant'> {
+	status: string;
+	label?: React.ReactNode;
+	color?: BadgeProps['color'];
+	variant?: BadgeProps['variant'];
+	className?: string;
+}
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({
+	status,
+	label,
+	color,
+	variant,
+	className,
+	radius = 'sm',
+	tt = 'none',
+	...props
+}) => {
+	const normalizedStatus = status.toUpperCase() as PresetStatus;
+	const preset = STATUS_META[normalizedStatus];
+
+	const resolvedLabel = label ?? preset?.label ?? status;
+	const resolvedColor = color ?? preset?.color ?? 'gray';
+	const resolvedVariant = variant ?? preset?.variant ?? 'light';
+
+	return (
+		<Badge
+			color={resolvedColor}
+			variant={resolvedVariant}
+			radius={radius}
+			tt={tt}
+			className={[
+				'font-semibold tracking-wide',
+				className,
+			]
+				.filter(Boolean)
+				.join(' ')}
+			{...props}
+		>
+			{resolvedLabel}
+		</Badge>
+	);
+};


### PR DESCRIPTION
Implemented a reusable UI component suite in client/src/components/ui, including Button, Modal, ConfirmDialog, DataTable, EmptyState, FormField, LoadingSpinner, and StatusBadge.