### PR TITLE
chore: Remove License section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,3 @@ All endpoints are prefixed with `/api`.
 | Loyalty | `/loyalty` |
 | Reviews | `/reviews` |
 | Statistics | `/statistics` |
-
-## License
-
-MIT


### PR DESCRIPTION
Removed the License section from the README.